### PR TITLE
Print versioninfo in llvm-svn build to get the llvm version number

### DIFF
--- a/master/nightly_llvmsvn.py
+++ b/master/nightly_llvmsvn.py
@@ -49,6 +49,12 @@ julia_llvmsvn_factory.addSteps([
     	haltOnFailure = True
     ),
 
+    # Print versioninfo. This is particularly useful for llvm-svn build
+    # since it includes the llvm version number.
+    ShellCommand(
+    	name="versioninfo()",
+    	command=["usr/bin/julia", "-f", "-e", "versioninfo()"]
+    ),
     # Test!
     ShellCommand(
     	name="make testall",


### PR DESCRIPTION
The LLVM version doesn't seem to be shown anywhere else otherwise.

@staticfloat 