### PR TITLE
Set `LLVM_CMAKE` on ARM buildbot

### DIFF
--- a/master/inventory.py
+++ b/master/inventory.py
@@ -23,7 +23,8 @@ c['slaves'] = []
 for name in all_names:
     # Initialize march to none, as some buildbots (power8) don't set it
     march = None
-   
+    llvm_cmake = None
+
     # Everything should be VERBOSE
     flags = 'VERBOSE=1 '
 
@@ -59,6 +60,10 @@ for name in all_names:
         # Add Link-Time-Optimization to ARM builder to work around this GCC bug:
         # https://github.com/JuliaLang/julia/issues/14550
         flags += 'LLVM_LTO=1 '
+        # Force LLVM cmake build to use the armv7 triple instead of picking
+        # up armv8 from uname
+        # This might not be an actual issue since we are not building clang
+        llvm_cmake = '-DLLVM_HOST_TRIPLE=armv7l-unknown-linux-gnueabihf -DLLVM_DEFAULT_TARGET_TRIPLE=armv7l-unknown-linux-gnueabihf'
 
     if name[-7:] == 'ppc64le':
         deb_arch = 'ppc64el'
@@ -107,6 +112,7 @@ for name in all_names:
 			'release':name,
 			'flags':flags,
 			'up_arch':up_arch,
-			'bits':bits
+			'bits':bits,
+			'llvm_cmake':llvm_cmake
 		}
 	)]

--- a/master/package_tarball.py
+++ b/master/package_tarball.py
@@ -42,7 +42,8 @@ julia_tarball_factory.addSteps([
         command=["/bin/bash", "-c", Interpolate("make -j3 %(prop:flags)s debug release")],
         haltOnFailure = True,
         timeout=2400,
-        env={'CFLAGS':None, 'CPPFLAGS':None},
+        env={'CFLAGS':None, 'CPPFLAGS':None,
+             'LLVM_CMAKE':Property('llvm_cmake', default=None)},
     ),
 
     # Make!
@@ -51,7 +52,8 @@ julia_tarball_factory.addSteps([
         command=["/bin/bash", "-c", Interpolate("make %(prop:flags)s binary-dist")],
         haltOnFailure = True,
         timeout=2400,
-        env={'CFLAGS':None, 'CPPFLAGS':None},
+        env={'CFLAGS':None, 'CPPFLAGS':None,
+             'LLVM_CMAKE':Property('llvm_cmake', default=None)},
     ),
 
     # Set a bunch of properties that everyone will need


### PR DESCRIPTION
So that the default tripple is set to ARMv7 instead of ARMv8.

Thanks to @staticfloat for showing me the right API to pass this value as a property...

Assuming this does not break the buildbot setup (like, due to a syntax error....) I'm planing to test this by triggering a force build on a branch that sets the default LLVM version to 3.9 on arm (and do that on master if everything works ok).
